### PR TITLE
feat: add restore-backup.sh

### DIFF
--- a/crivo/restore-volume.sh
+++ b/crivo/restore-volume.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+
+TARFILE=$(pwd)/backup-2025-05-07-novotes.tar.gz
+# https://www.dcc.ufmg.br/~cunha/hosted/crivo-metadata-d1a2c69c-1ebd-11f0-a0cf-a7cc2967d76b/backup-2025-05-07-novotes.tar.gz
+VOLUME=test_defectdojo_crivo
+
+if [[ "$TARFILE" != /* ]]; then
+    echo "Error: TARFILE path must be absolute"
+    exit 1
+fi
+
+if ! docker volume ls -q | grep -w $VOLUME &>/dev/null; then
+    echo "docker volume $VOLUME not found, creating"
+    docker volume create $VOLUME
+fi
+
+docker run --rm \
+	-v $VOLUME:/volume \
+	-v "$TARFILE:/app/backup.tar.gz" \
+	busybox \
+	sh -c "cd /volume && tar xzf /app/backup.tar.gz && chmod -R 777 ."


### PR DESCRIPTION
This script loads a previosly-computed metadata tarfile into a Docker volume. This is useful to avoid re-downloading the data from NVD and other authoritative databases repeatedly. At UFMG, at least, our server seems to have been rate-limited and can no longer reliably download all needed files when running the crivo-init container.